### PR TITLE
Feat: enable only one jet LSP per filetype

### DIFF
--- a/doc/jet.txt
+++ b/doc/jet.txt
@@ -52,26 +52,8 @@ Lua API                                                                *lua-api*
                                          end
                                      })
 <
-        • {hooks}                (`jet.Config.Hooks`) These functions run at
-                                 different points in the kernel lifecycle and
-                                 can be used to customise behaviour. For
-                                 example, `on_message_received()` triggers
-                                 whenever a message is received from the
-                                 kernel and is passed the full message data.
-                                 E.g. you could set up a notification whenever
-                                 an execution completes like so: >lua
-                                     require("jet").setup({
-                                         hooks = {
-                                             on_message_received = {
-                                                 my_notifier = function(k, msg)
-                                                     if msg.header.msg_type == "execute_reply" then
-                                                         vim.notify(k.spec.display_name .. ": execution complete")
-                                                     end
-                                                 end
-                                             }
-                                         }
-                                     })
-<
+        • {hooks}                (`jet.Hooks`) Hooks for custom integrations;
+                                 see |jet.Hooks|.
         • {send}                 (`{ send_by_expr = boolean }`)
                                  • `send.send_by_expr`: If `true` (the
                                    default) then each expression will be sent
@@ -103,17 +85,7 @@ Lua API                                                                *lua-api*
                                        issue in reedline, which powers the Jet
                                        REPL experience..
 
-*jet.Config.Hooks*
-
-    Fields: ~
-        • {on_execution_state_changed}  (`table<any,fun(k: jet.Kernel, state: jet.Kernel.execution_state)>`)
-        • {on_kernel_close}             (`table<any,fun(k: jet.Kernel)>`)
-        • {on_kernel_init}              (`table<any,fun(k: jet.Kernel)>`)
-        • {on_lua_client_start}         (`table<any,fun(k: jet.Kernel)>`)
-        • {on_message_received}         (`table<any,fun(k: jet.Kernel, msg: jupyter.Msg)>`)
-        • {on_send_pre}                 (`table<any,fun(k: jet.Kernel, code: string[])>`)
-        • {on_status_changed}           (`table<any,fun(k: jet.Kernel)>`)
-        • {on_image_display_pre}        (`table<any,fun(k: jet.Kernel, file: string)>`)
+        Type not found
 
 *jet.Kernel*
 
@@ -137,7 +109,7 @@ Lua API                                                                *lua-api*
         • {session_id}           (`string?`)
         • {session_info}         (`jet.SessionInfo?`)
         • {client_id}            (`string?`)
-        • {lsp_port}             (`integer?`)
+        • {lsp}                  (`jet.Lsp`)
         • {term}                 (`jet.Kernel.Term?`)
         • {img}                  (`jet.Kernel.Img?`)
         • {cmd}                  (`string[]`)
@@ -154,8 +126,7 @@ Lua API                                                                *lua-api*
         • {metadata}             (`table<string,any>`) Arbitrary data,
                                  e.g. for use by extensions
         • {stream}               (`jet.callback<jupyter.Msg>`)
-        • {hooks}                (`jet.Config.Hooks`)
-        • {lsp_name}             (`string`)
+        • {hooks}                (`jet.Hooks`)
 
 Kernel:init_owned({opts})                                  *Kernel:init_owned()*
 
@@ -199,11 +170,6 @@ Kernel:status()                                                *Kernel:status()*
     Return: ~
         (`jet.kernel.status`)
         (`string`)
-
-Kernel:set_as_filetype_primary()              *Kernel:set_as_filetype_primary()*
-
-    Set the kernel as the 'primary' kernel for its filetype. No-op if the
-    kernel has no filetype.
 
 Kernel:img_dir()                                              *Kernel:img_dir()*
 

--- a/lua/jet/core/config.lua
+++ b/lua/jet/core/config.lua
@@ -1,16 +1,5 @@
 local M = {}
 
----@class jet.Config.Hooks
----@field on_execution_state_changed table<any, fun(k: jet.Kernel, state: jet.Kernel.execution_state)>
----@field on_kernel_close table<any, fun(k: jet.Kernel)>
----@field on_kernel_init table<any, fun(k: jet.Kernel)>
----@field on_lua_client_start table<any, fun(k: jet.Kernel)>
----@field on_message_received table<any, fun(k: jet.Kernel, msg: jupyter.Msg)>
----@field on_send_pre table<any, fun(k: jet.Kernel, code: string[])>
----@field on_status_changed table<any, fun(k: jet.Kernel)>
----@field on_image_display_pre table<any, fun(k: jet.Kernel, file: string)>
----@field on_primary_status_changed table<any, fun(k: jet.Kernel, primary: boolean)>
-
 ---@class jet.Config.Opts
 M.defaults = {
 	binary_path = nil, ---@type string? Path to a custom Jet binary.
@@ -56,36 +45,8 @@ M.defaults = {
 	--- })
 	--- ```
 	time_formatter = nil, ---@type nil | fun(hh: integer, mm: integer, ss: integer): string
-	---These functions run at different points in the kernel lifecycle and can
-	---be used to customise behaviour. For example, `on_message_received()`
-	---triggers whenever a message is received from the kernel and is passed
-	---the full message data. E.g. you could set up a notification whenever an
-	---execution completes like so:
-	---``` lua
-	---require("jet").setup({
-	---    hooks = {
-	---        on_message_received = {
-	---            my_notifier = function(k, msg)
-	---                if msg.header.msg_type == "execute_reply" then
-	---                    vim.notify(k.spec.display_name .. ": execution complete")
-	---                end
-	---            end
-	---        }
-	---    }
-	---})
-	---```
-	---@type jet.Config.Hooks
-	hooks = {
-		on_execution_state_changed = {},
-		on_kernel_close = {},
-		on_kernel_init = {},
-		on_lua_client_start = {},
-		on_message_received = {},
-		on_send_pre = {},
-		on_status_changed = {},
-		on_image_display_pre = {},
-		on_primary_status_changed = {},
-	},
+	---Hooks for custom integrations; see |jet.Hooks|.
+	hooks = require("jet.core.hooks").init_hooks(),
 	---* `send.send_by_expr`: If `true` (the default) then each expression will
 	---  be sent and results shown one at a time. If `false`, then when sending
 	---  several complete expressions to the repl in one go, all will be

--- a/lua/jet/core/config.lua
+++ b/lua/jet/core/config.lua
@@ -9,6 +9,7 @@ local M = {}
 ---@field on_send_pre table<any, fun(k: jet.Kernel, code: string[])>
 ---@field on_status_changed table<any, fun(k: jet.Kernel)>
 ---@field on_image_display_pre table<any, fun(k: jet.Kernel, file: string)>
+---@field on_primary_status_changed table<any, fun(k: jet.Kernel, primary: boolean)>
 
 ---@class jet.Config.Opts
 M.defaults = {
@@ -83,6 +84,7 @@ M.defaults = {
 		on_send_pre = {},
 		on_status_changed = {},
 		on_image_display_pre = {},
+		on_primary_status_changed = {},
 	},
 	---* `send.send_by_expr`: If `true` (the default) then each expression will
 	---  be sent and results shown one at a time. If `false`, then when sending

--- a/lua/jet/core/hooks.lua
+++ b/lua/jet/core/hooks.lua
@@ -1,0 +1,102 @@
+local M = {}
+
+M.init_hooks = function()
+	---These functions run at different points in the kernel lifecycle and can
+	---be used to customise behaviour. For example, `on_message_received()`
+	---triggers whenever jet.nvim receives a message from the kernel, and it
+	---receives the the full message data. You can use this to implement custom
+	---behaviour, such as notifications which fire whenever an execution
+	---completes, like so:
+	---``` lua
+	---require("jet").setup({
+	---    hooks = {
+	---        on_message_received = {
+	---            my_notifier = function(k, msg)
+	---                if msg.header.msg_type == "execute_reply" then
+	---                    vim.notify(k.spec.display_name .. ": execution complete")
+	---                end
+	---            end
+	---        }
+	---    }
+	---})
+	---```
+	---@class jet.Hooks
+	local hooks = {
+		---@type table<any, fun(k: jet.Kernel, state: jet.Kernel.execution_state)>
+		on_execution_state_changed = {},
+
+		---@type table<any, fun(k: jet.Kernel)>
+		on_kernel_close = {},
+
+		---@type table<any, fun(k: jet.Kernel)>
+		on_kernel_init = {},
+
+		---@type table<any, fun(k: jet.Kernel)>
+		on_lua_client_start = {},
+
+		---@type table<any, fun(k: jet.Kernel, msg: jupyter.Msg)>
+		on_message_received = {},
+
+		---@type table<any, fun(k: jet.Kernel, code: string[])>
+		on_send_pre = {},
+
+		---@type table<any, fun(k: jet.Kernel)>
+		on_status_changed = {},
+
+		---@type table<any, fun(k: jet.Kernel, file: string)>
+		on_image_display_pre = {},
+
+		---@type table<any, fun(k: jet.Kernel, primary: boolean)>
+		on_primary_status_changed = {},
+	}
+
+	return hooks
+end
+
+local h = M.init_hooks()
+
+---A rather grim implementation, but it gives type hints _and_ calls both the
+---kernel-specific hooks and the global hooks.
+---@generic T
+---@param hooks table<string | integer, T>
+---@return T
+local function make_caller(hooks)
+	local hook_name = ""
+	for name, hook_table in pairs(h) do
+		if hook_table == hooks then
+			hook_name = name
+			break
+		end
+	end
+
+	assert(hook_name ~= "", "Could not determine which hook is being called")
+
+	---@param k jet.Kernel
+	return function(k, ...)
+		local config_hooks = require("jet.core.config").options.hooks[hook_name]
+		local kernel_hooks = k.hooks[hook_name]
+
+		---@diagnostic disable-next-line: param-type-mismatch
+		for _, hook in pairs(kernel_hooks) do
+			hook(k, ...)
+		end
+		---@diagnostic disable-next-line: param-type-mismatch
+		for _, hook in pairs(config_hooks) do
+			hook(k, ...)
+		end
+	end
+end
+
+-- stylua: ignore start
+M.do_execution_state_changed = make_caller(h.on_execution_state_changed)
+M.do_kernel_close            = make_caller(h.on_kernel_close)
+M.do_kernel_init             = make_caller(h.on_kernel_init)
+M.do_lua_client_start        = make_caller(h.on_lua_client_start)
+M.do_message_received        = make_caller(h.on_message_received)
+M.do_send_pre                = make_caller(h.on_send_pre)
+M.do_status_changed          = make_caller(h.on_status_changed)
+M.do_image_display_pre       = make_caller(h.on_image_display_pre)
+M.do_primary_status_changed  = make_caller(h.on_primary_status_changed)
+-- stylua: ignore end
+
+return M

--- a/lua/jet/core/kernel/img.lua
+++ b/lua/jet/core/kernel/img.lua
@@ -101,7 +101,7 @@ function Img:display(which)
 	local src = vim.fs.joinpath(self.kernel:img_dir(), filepath)
 
 	---@diagnostic disable-next-line: access-invisible
-	self.kernel:do_image_display_pre(src)
+	require("jet.core.hooks").do_image_display_pre(self.kernel, src)
 
 	-- First try Snacks
 	if _G.Snacks and _G.Snacks.image and _G.Snacks.image.config then

--- a/lua/jet/core/kernel/init.lua
+++ b/lua/jet/core/kernel/init.lua
@@ -678,6 +678,7 @@ function Kernel:start_lua_client(callback)
 				client_id = val.client_id,
 				display_name = self.spec.display_name,
 				filetype = self.filetype,
+				session_id = self.session_id,
 			})
 
 			-- Even though the kernel has not yet been shown in a REPL, if

--- a/lua/jet/core/kernel/init.lua
+++ b/lua/jet/core/kernel/init.lua
@@ -74,6 +74,7 @@ local init_defaults = function()
 			on_send_pre = {},
 			on_status_changed = {},
 			on_image_display_pre = {},
+			on_primary_status_changed = {},
 		},
 	}
 end
@@ -169,6 +170,7 @@ Kernel.do_message_received        = make_hook_caller(cfg.hooks.on_message_receiv
 Kernel.do_send_pre                = make_hook_caller(cfg.hooks.on_send_pre) ---@private
 Kernel.do_status_changed          = make_hook_caller(cfg.hooks.on_status_changed) ---@private
 Kernel.do_image_display_pre       = make_hook_caller(cfg.hooks.on_image_display_pre) ---@private
+Kernel.do_primary_status_changed  = make_hook_caller(cfg.hooks.on_primary_status_changed) ---@private
 -- stylua: ignore end
 
 ---Toggle the terminal window for the kernel.

--- a/lua/jet/core/kernel/init.lua
+++ b/lua/jet/core/kernel/init.lua
@@ -1,6 +1,7 @@
 local manager = require("jet.core.manager")
 local cfg = require("jet.core.config").options
 local utils = require("jet.core.utils")
+local lsp = require("jet.core.kernel.lsp")
 
 local STARTING_KERNEL_SENTINEL = "<pending>"
 
@@ -30,7 +31,7 @@ local STARTING_KERNEL_SENTINEL = "<pending>"
 ---@field session_id? string
 ---@field session_info? jet.SessionInfo
 ---@field client_id? string
----@field lsp_port? integer
+---@field lsp jet.Lsp
 ---@field term? jet.Kernel.Term
 ---@field img? jet.Kernel.Img
 ---@field cmd string[]
@@ -207,7 +208,7 @@ function Kernel:term_create(callback)
 		if not self.term then
 			assert(self.session_id, "Kernel has no session id")
 			self.term = require("jet.core.kernel.term").init({ kernel = self, ns = jet_hl_ns })
-			self.term:create_autocmd("TermEnter", function() self:set_as_filetype_primary() end)
+			self.term:create_autocmd("TermEnter", function() manager:set_primary(self) end)
 			if cfg.stop_on_buf_wipeout then
 				self.term:create_autocmd("BufWipeout", function() self:close("BufWipeout") end)
 			end
@@ -231,16 +232,6 @@ function Kernel:status()
 	else
 		return "inactive", " "
 	end
-end
-
----Set the kernel as the 'primary' kernel for its filetype. No-op if the kernel
----has no filetype.
-function Kernel:set_as_filetype_primary()
-	if not self.filetype then
-		return
-	end
-
-	manager.filetype_primary[self.filetype] = self.session_id
 end
 
 ---@param s string
@@ -607,42 +598,6 @@ function Kernel:handle_stream()
 	end, { alias = "Watch for kernel stream messages " .. self.session_id })
 end
 
----@private
-function Kernel:register_lsp_client()
-	if not self.filetype then
-		return
-	end
-
-	assert(self.lsp_port, "Kernel has no lsp port")
-	assert(self.client_id, "Kernel has no client id")
-	---@diagnostic disable-next-line: unnecessary-assert
-	assert(self.spec and self.spec.display_name, "Kernel has no display name")
-
-	local clean_name = self.spec.display_name:gsub("%W", "_"):gsub("_+", "_"):gsub("^_+", ""):gsub("_+$", "")
-	self.lsp_name = "jet_" .. clean_name .. "_" .. self.client_id
-
-	local capabilities = vim.lsp.protocol.make_client_capabilities()
-
-	vim.lsp.config(self.lsp_name, {
-		cmd = vim.lsp.rpc.connect("127.0.0.1", self.lsp_port),
-		root_markers = { ".git" },
-		filetypes = { self.filetype },
-		root_dir = ".",
-		capabilities = {
-			general = capabilities.general,
-			textDocument = {
-				completion = (capabilities.textDocument or {}).completion,
-				-- hover = {
-				-- 	dynamicRegistration = true,
-				-- 	contentFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
-				-- },
-			},
-		},
-	})
-
-	vim.lsp.enable(self.lsp_name)
-end
-
 ---Connect to a real kernel instance using the Jet Lua client.
 ---
 ---When a kernel is opened, the Lua client starts first, possibly starting a
@@ -710,7 +665,6 @@ function Kernel:start_lua_client(callback)
 		if val then
 			utils.log_info("Started kernel '%s' (%s)", self.spec.display_name, self.session_id)
 
-			self.lsp_port = val.lsp_port
 			self.client_id = val.client_id
 			self.kernel_info = val.kernel_info
 			self.stream = val.stream
@@ -719,15 +673,21 @@ function Kernel:start_lua_client(callback)
 			-- has a chance to override it.
 			self:try_resolve_filetype()
 
+			self.lsp = lsp.init({
+				port = val.lsp_port,
+				client_id = val.client_id,
+				display_name = self.spec.display_name,
+				filetype = self.filetype,
+			})
+
 			-- Even though the kernel has not yet been shown in a REPL, if
 			-- there isn't another kernel for this filetype already set as
 			-- primary we should set this one for convenience.
 			if self.filetype and not manager.filetype_primary[self.filetype] then
-				self:set_as_filetype_primary()
+				manager:set_primary(self)
 			end
 
 			self:handle_stream()
-			self:register_lsp_client()
 
 			self:do_lua_client_start()
 			self:do_status_changed()

--- a/lua/jet/core/kernel/init.lua
+++ b/lua/jet/core/kernel/init.lua
@@ -2,6 +2,7 @@ local manager = require("jet.core.manager")
 local cfg = require("jet.core.config").options
 local utils = require("jet.core.utils")
 local lsp = require("jet.core.kernel.lsp")
+local hooks = require("jet.core.hooks")
 
 local STARTING_KERNEL_SENTINEL = "<pending>"
 
@@ -47,7 +48,7 @@ local STARTING_KERNEL_SENTINEL = "<pending>"
 ---@field on_started table<string, fun(k: jet.Kernel)>
 ---@field metadata table<string, any> Arbitrary data, e.g. for use by extensions
 ---@field stream jet.callback<jupyter.Msg>
----@field hooks jet.Config.Hooks
+---@field hooks jet.Hooks
 ---@field private augroup? integer
 local Kernel = {}
 Kernel.__index = Kernel ---@private
@@ -65,17 +66,7 @@ local init_defaults = function()
 		on_message_received = {},
 		on_started = {},
 		metadata = {},
-		hooks = {
-			on_execution_state_changed = {},
-			on_kernel_close = {},
-			on_kernel_init = {},
-			on_lua_client_start = {},
-			on_message_received = {},
-			on_send_pre = {},
-			on_status_changed = {},
-			on_image_display_pre = {},
-			on_primary_status_changed = {},
-		},
+		hooks = hooks.init_hooks(),
 	}
 end
 
@@ -135,42 +126,16 @@ function Kernel.init_external(opts)
 	return out
 end
 
----A rather grim implementation, but it gives type hints _and_ calls both the
----kernel-specific hooks and the global hooks.
----@generic T
----@param hooks table<string | integer, T>
----@return T
-local function make_hook_caller(hooks)
-	local hook_name
-	for name, hookset in pairs(cfg.hooks) do
-		if hookset == hooks then
-			hook_name = name
-		end
-	end
-
-	---@param k jet.Kernel
-	return function(k, ...)
-		if hook_name and k.hooks[hook_name] then
-			for _, hook in pairs(k.hooks[hook_name]) do
-				hook(k, ...)
-			end
-		end
-		for _, hook in pairs(hooks) do
-			hook(k, ...)
-		end
-	end
-end
-
 -- stylua: ignore start
-Kernel.do_execution_state_changed = make_hook_caller(cfg.hooks.on_execution_state_changed) ---@private
-Kernel.do_kernel_close            = make_hook_caller(cfg.hooks.on_kernel_close) ---@private
-Kernel.do_kernel_init             = make_hook_caller(cfg.hooks.on_kernel_init) ---@private
-Kernel.do_lua_client_start        = make_hook_caller(cfg.hooks.on_lua_client_start) ---@private
-Kernel.do_message_received        = make_hook_caller(cfg.hooks.on_message_received) ---@private
-Kernel.do_send_pre                = make_hook_caller(cfg.hooks.on_send_pre) ---@private
-Kernel.do_status_changed          = make_hook_caller(cfg.hooks.on_status_changed) ---@private
-Kernel.do_image_display_pre       = make_hook_caller(cfg.hooks.on_image_display_pre) ---@private
-Kernel.do_primary_status_changed  = make_hook_caller(cfg.hooks.on_primary_status_changed) ---@private
+Kernel.do_execution_state_changed = hooks.do_execution_state_changed ---@private
+Kernel.do_kernel_close            = hooks.do_kernel_close            ---@private
+Kernel.do_kernel_init             = hooks.do_kernel_init             ---@private
+Kernel.do_lua_client_start        = hooks.do_lua_client_start        ---@private
+Kernel.do_message_received        = hooks.do_message_received        ---@private
+Kernel.do_send_pre                = hooks.do_send_pre                ---@private
+Kernel.do_status_changed          = hooks.do_status_changed          ---@private
+Kernel.do_image_display_pre       = hooks.do_image_display_pre       ---@private
+Kernel.do_primary_status_changed  = hooks.do_primary_status_changed  ---@private
 -- stylua: ignore end
 
 ---Toggle the terminal window for the kernel.

--- a/lua/jet/core/kernel/lsp.lua
+++ b/lua/jet/core/kernel/lsp.lua
@@ -1,0 +1,54 @@
+-- local utils = require("jet.core.utils")
+
+---@class jet.Lsp
+---@field port integer
+---@field name string
+---@field filetype string
+local Lsp = {}
+Lsp.__index = Lsp ---@private
+
+---@class jet.Lsp.init.Opts
+---@field port integer
+---@field filetype string?
+---@field client_id string
+---@field display_name string
+
+---@param opts jet.Lsp.init.Opts
+function Lsp.init(opts)
+	local out = setmetatable({
+		name = string.format(
+			"jet_%s_%s",
+			opts.display_name:gsub("%W", "_"):gsub("_+", "_"):gsub("^_+", ""):gsub("_+$", ""),
+			opts.client_id
+		),
+		port = opts.port,
+		filetype = opts.filetype,
+	}, Lsp)
+
+	local capabilities = vim.lsp.protocol.make_client_capabilities()
+
+	vim.lsp.config(out.name, {
+		cmd = vim.lsp.rpc.connect("127.0.0.1", out.port),
+		root_markers = { ".git" },
+		filetypes = { out.filetype },
+		root_dir = ".",
+		capabilities = {
+			general = capabilities.general,
+			textDocument = {
+				completion = (capabilities.textDocument or {}).completion,
+				-- hover = {
+				-- 	dynamicRegistration = true,
+				-- 	contentFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
+				-- },
+			},
+		},
+	})
+
+	return out
+end
+
+function Lsp:enable() vim.lsp.enable(self.name) end
+function Lsp:disable() vim.lsp.enable(self.name, false) end
+function Lsp:is_enabled() return vim.lsp.is_enabled(self.name) end
+
+return Lsp

--- a/lua/jet/core/kernel/lsp.lua
+++ b/lua/jet/core/kernel/lsp.lua
@@ -16,6 +16,7 @@ Lsp.__index = Lsp ---@private
 ---@param opts jet.Lsp.init.Opts
 function Lsp.init(opts)
 	local out = setmetatable({
+		sesssion = opts.session_id,
 		name = string.format(
 			"jet_%s_%s",
 			opts.display_name:gsub("%W", "_"):gsub("_+", "_"):gsub("^_+", ""):gsub("_+$", ""),
@@ -25,30 +26,44 @@ function Lsp.init(opts)
 		filetype = opts.filetype,
 	}, Lsp)
 
-	local capabilities = vim.lsp.protocol.make_client_capabilities()
-
-	vim.lsp.config(out.name, {
-		cmd = vim.lsp.rpc.connect("127.0.0.1", out.port),
-		root_markers = { ".git" },
-		filetypes = { out.filetype },
-		root_dir = ".",
-		capabilities = {
-			general = capabilities.general,
-			textDocument = {
-				completion = (capabilities.textDocument or {}).completion,
-				-- hover = {
-				-- 	dynamicRegistration = true,
-				-- 	contentFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
-				-- },
-			},
-		},
-	})
-
 	return out
 end
 
-function Lsp:enable() vim.lsp.enable(self.name) end
-function Lsp:disable() vim.lsp.enable(self.name, false) end
-function Lsp:is_enabled() return vim.lsp.is_enabled(self.name) end
+local make_capabilities = function()
+	local capabilities = vim.lsp.protocol.make_client_capabilities()
+	return {
+		general = capabilities.general,
+		textDocument = {
+			completion = (capabilities.textDocument or {}).completion,
+			-- hover = {
+			-- 	dynamicRegistration = true,
+			-- 	contentFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
+			-- },
+		},
+	}
+end
+
+function Lsp:configure()
+	vim.lsp.config(self.name, {
+		cmd = vim.lsp.rpc.connect("127.0.0.1", self.port),
+		root_markers = { ".git" },
+		filetypes = { self.filetype },
+		root_dir = ".",
+		capabilities = make_capabilities(),
+	})
+end
+
+function Lsp:enable()
+	if not vim.lsp.is_enabled(self.name) then
+		print("enabling " .. vim.inspect(self))
+		self:configure()
+		vim.lsp.enable(self.name)
+	end
+end
+
+function Lsp:disable()
+	print("disabling " .. vim.inspect(self))
+	vim.lsp.enable(self.name, false)
+end
 
 return Lsp

--- a/lua/jet/core/kernel/lsp.lua
+++ b/lua/jet/core/kernel/lsp.lua
@@ -16,7 +16,6 @@ Lsp.__index = Lsp ---@private
 ---@param opts jet.Lsp.init.Opts
 function Lsp.init(opts)
 	local out = setmetatable({
-		sesssion = opts.session_id,
 		name = string.format(
 			"jet_%s_%s",
 			opts.display_name:gsub("%W", "_"):gsub("_+", "_"):gsub("^_+", ""):gsub("_+$", ""),
@@ -29,41 +28,33 @@ function Lsp.init(opts)
 	return out
 end
 
-local make_capabilities = function()
-	local capabilities = vim.lsp.protocol.make_client_capabilities()
-	return {
-		general = capabilities.general,
-		textDocument = {
-			completion = (capabilities.textDocument or {}).completion,
-			-- hover = {
-			-- 	dynamicRegistration = true,
-			-- 	contentFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
-			-- },
-		},
-	}
-end
-
 function Lsp:configure()
+	local capabilities = vim.lsp.protocol.make_client_capabilities()
 	vim.lsp.config(self.name, {
 		cmd = vim.lsp.rpc.connect("127.0.0.1", self.port),
 		root_markers = { ".git" },
 		filetypes = { self.filetype },
 		root_dir = ".",
-		capabilities = make_capabilities(),
+		capabilities = {
+			general = capabilities.general,
+			textDocument = {
+				completion = (capabilities.textDocument or {}).completion,
+				-- hover = {
+				-- 	dynamicRegistration = true,
+				-- 	contentFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
+				-- },
+			},
+		},
 	})
 end
 
 function Lsp:enable()
 	if not vim.lsp.is_enabled(self.name) then
-		print("enabling " .. vim.inspect(self))
 		self:configure()
 		vim.lsp.enable(self.name)
 	end
 end
 
-function Lsp:disable()
-	print("disabling " .. vim.inspect(self))
-	vim.lsp.enable(self.name, false)
-end
+function Lsp:disable() vim.lsp.enable(self.name, false) end
 
 return Lsp

--- a/lua/jet/core/manager.lua
+++ b/lua/jet/core/manager.lua
@@ -14,6 +14,29 @@ function Manager:insert(k)
 	self.kernels[k.session_id] = k
 end
 
+---Also activates the kernel LSP and disables any other active Jet LSP for the
+---same filetype.
+---
+---@param k jet.Kernel
+function Manager:set_primary(k)
+	assert(k.session_id, "Kernel must have a session_id")
+	assert(k.filetype, "Kernel must have a filetype")
+
+	self.kernels[k.session_id] = k
+	self.filetype_primary[k.filetype] = k.session_id
+
+	-- We only want one active Jet LSP per filetype
+	for _, ki in pairs(self.kernels) do
+		if ki ~= k and ki.filetype == k.filetype and ki.lsp then
+			ki.lsp:disable()
+		end
+	end
+
+	if k.lsp then
+		k.lsp:enable()
+	end
+end
+
 ---@class jet.api.Filters
 ---@field session_id? string Implies `status` = "connected" or "external"
 ---@field spec_path? string

--- a/lua/jet/core/manager.lua
+++ b/lua/jet/core/manager.lua
@@ -29,12 +29,11 @@ function Manager:set_primary(k)
 	self.filetype_primary[k.filetype] = k.session_id
 
 	if prev_primary ~= k.session_id then
+		local h = require("jet.core.hooks")
 		if prev_primary and self.kernels[prev_primary] then
-			---@diagnostic disable-next-line: access-invisible
-			self.kernels[prev_primary]:do_primary_status_changed(false)
+			h.do_primary_status_changed(self.kernels[prev_primary], false)
 		end
-		---@diagnostic disable-next-line: access-invisible
-		k:do_primary_status_changed(true)
+		h.do_primary_status_changed(k, true)
 	end
 
 	-- We only want one active Jet LSP per filetype

--- a/lua/jet/core/manager.lua
+++ b/lua/jet/core/manager.lua
@@ -19,11 +19,23 @@ end
 ---
 ---@param k jet.Kernel
 function Manager:set_primary(k)
+	print("setting primary kernel")
 	assert(k.session_id, "Kernel must have a session_id")
 	assert(k.filetype, "Kernel must have a filetype")
 
+	local prev_primary = self.filetype_primary[k.filetype]
+
 	self.kernels[k.session_id] = k
 	self.filetype_primary[k.filetype] = k.session_id
+
+	if prev_primary ~= k.session_id then
+		if prev_primary and self.kernels[prev_primary] then
+			---@diagnostic disable-next-line: access-invisible
+			self.kernels[prev_primary]:do_primary_status_changed(false)
+		end
+		---@diagnostic disable-next-line: access-invisible
+		k:do_primary_status_changed(true)
+	end
 
 	-- We only want one active Jet LSP per filetype
 	for _, ki in pairs(self.kernels) do

--- a/tests/test_lsp_primary_completion.lua
+++ b/tests/test_lsp_primary_completion.lua
@@ -1,0 +1,111 @@
+local MiniTest = require("mini.test")
+local child = MiniTest.new_child_neovim()
+local eq = MiniTest.expect.equality
+
+local T = MiniTest.new_set({
+	hooks = {
+		pre_case = function() child.restart({ "-u", "scripts/minimal_init.lua" }) end,
+		post_once = child.stop,
+	},
+})
+
+local SPEC = "test-kernels/python3/kernel.json"
+
+local start_kernel = function(name)
+	child.lua(([[
+		_G.%s = require("jet.core.kernel").init_owned({ spec_path = %q })
+		_G.%s:start_lua_client()
+	]]):format(name, SPEC, name))
+
+	local predicate = ([[
+		_G.%s and _G.%s.client_id and _G.%s.client_id ~= "<pending>"
+		and _G.%s.lsp and _G.%s.filetype == "python"
+	]]):format(name, name, name, name, name)
+	assert(vim.wait(20000, function() return child.lua_get(predicate) end, 100), name .. " did not start")
+end
+
+local run_code = function(name, code)
+	child.lua(([[ _G.%s:send_lua(%q, true) ]]):format(name, code))
+	local predicate = ([[ _G.%s.execution_state == "idle" ]]):format(name)
+	assert(vim.wait(10000, function() return child.lua_get(predicate) end, 50), name .. " never returned to idle")
+end
+
+local open_python_buf = function()
+	child.lua([[
+		vim.cmd("enew")
+		_G.buf = vim.api.nvim_get_current_buf()
+		vim.bo[_G.buf].filetype = "python"
+	]])
+
+	assert(
+		vim.wait(10000, function()
+			return child.lua_get([[
+				(function()
+					for _, c in ipairs(vim.lsp.get_clients({ bufnr = _G.buf })) do
+						if c.name:sub(1,4) == "jet_" then return true end
+					end
+					return false
+				end)()
+			]])
+		end, 50),
+		"No jet_* LSP attached to python buffer"
+	)
+end
+
+local set_primary = function(name)
+	child.lua(([[ require("jet.core.manager"):set_primary(_G.%s) ]]):format(name))
+	vim.wait(500)
+end
+
+-- Ask every attached jet_* client for completions and return the flat list of labels.
+local get_completions = function(prefix)
+	child.lua(([[
+		_G.labels, _G.pending = {}, 0
+		vim.api.nvim_buf_set_lines(_G.buf, 0, -1, false, { %q })
+		vim.api.nvim_win_set_cursor(0, { 1, %d })
+		local params = vim.lsp.util.make_position_params(0, "utf-16")
+		for _, c in ipairs(vim.lsp.get_clients({ bufnr = _G.buf })) do
+			if c.name:sub(1,4) == "jet_" then
+				_G.pending = _G.pending + 1
+				c:request("textDocument/completion", params, function(_err, result)
+					for _, it in ipairs((result or {}).items or result or {}) do
+						table.insert(_G.labels, it.label)
+					end
+					_G.pending = _G.pending - 1
+				end, _G.buf)
+			end
+		end
+	]]):format(prefix, #prefix))
+
+	vim.wait(3000, function() return child.lua_get("_G.pending == 0") end, 50)
+	return child.lua_get("_G.labels")
+end
+
+T["completions follow the primary kernel"] = MiniTest.new_set({
+	parametrize = {
+		{ "k2", "my_second_var", "my_first_var" },
+		{ "k1", "my_first_var", "my_second_var" },
+	},
+})
+
+T["completions follow the primary kernel"]["primary provides completions, others do not"] = function(
+	primary,
+	expected,
+	forbidden
+)
+	start_kernel("k1")
+	run_code("k1", "my_first_var = 1")
+	start_kernel("k2")
+	run_code("k2", "my_second_var = 2")
+
+	set_primary(primary)
+	open_python_buf()
+
+	local labels_expected = get_completions(expected:sub(1, -4)) -- strip "var"
+	eq(vim.tbl_contains(labels_expected, expected), true)
+
+	local labels_forbidden = get_completions(forbidden:sub(1, -4))
+	eq(vim.tbl_contains(labels_forbidden, forbidden), false)
+end
+
+return T

--- a/tests/test_lsp_primary_completion.lua
+++ b/tests/test_lsp_primary_completion.lua
@@ -38,8 +38,10 @@ local open_python_buf = function()
 	]])
 
 	assert(
-		vim.wait(10000, function()
-			return child.lua_get([[
+		vim.wait(
+			10000,
+			function()
+				return child.lua_get([[
 				(function()
 					for _, c in ipairs(vim.lsp.get_clients({ bufnr = _G.buf })) do
 						if c.name:sub(1,4) == "jet_" then return true end
@@ -47,7 +49,9 @@ local open_python_buf = function()
 					return false
 				end)()
 			]])
-		end, 50),
+			end,
+			50
+		),
 		"No jet_* LSP attached to python buffer"
 	)
 end


### PR DESCRIPTION
Close #11 

- **feat(lsp): only enable one jet lsp per filetyep**
- **feat(lsp): wip lsp toggling based on primary status**
- **test(lsp): add a test for lsp completions**
- **feat(hooks): add on_primary_status_changed hook**
- **refactor(hooks): implement hooks in hooks.lua again**
