### PR TITLE
Refactor 'send' code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-<h1 align="center">jet.nvim ✈️</h1>
+# <p align="center">jet.nvim ✈️</p>
 
-A Jupyter kernel supervisor for Neovim, built on top of
+A Jupyter frontend for Neovim, built on top of
 [Jet](https://github.com/wurli/jet).
 
 ## Features
 
-*   A REPL which runs in Neovim's built-in terminal
-*   Integration with Jet's LSP server which surfaces completions from the kernel
-    in your Neovim session
+*   A repl which runs in Neovim's built-in terminal
+*   An LSP server which surfaces completions from the kernel in your Neovim
+    session
 *   A Lua API which gives fine-grained control over running kernels, down to
     the level of individual Jupyter messages
 *   Ability to connect to kernel sessions running outside of Neovim
@@ -23,8 +23,6 @@ Using `vim.pack`:
 
 ``` lua
 vim.pack.add({ "https://github.com/wurli/jet.nvim" })
-
--- You'll need to call setup() for things to work correctly
 require("jet").setup({})
 ```
 

--- a/doc/jet.txt
+++ b/doc/jet.txt
@@ -7,7 +7,13 @@ jet.nvim is a Jupyter client/API for Neovim, built on top of the Jet
 https://github.com/wurli/jet CLI/Lua library.
 
 ------------------------------------------------------------------------------
-Lua API                                                                *lua-api*
+Installation                                                      *installation*
+
+>lua
+    vim.pack.add("https://github.com/wurli/jet.nvim")
+    require("jet").setup()
+<
+The full set of configuration options is as follows:
 
 *jet.Config.Opts*
 
@@ -85,7 +91,35 @@ Lua API                                                                *lua-api*
                                        issue in reedline, which powers the Jet
                                        REPL experience..
 
-        Type not found
+*jet.Hooks*
+
+    These functions run at different points in the kernel lifecycle and can be
+    used to customise behaviour. For example, `on_message_received()` triggers
+    whenever jet.nvim receives a message from the kernel, and it receives the
+    the full message data. You can use this to implement custom behaviour,
+    such as notifications which fire whenever an execution completes, like so: >lua
+        require("jet").setup({
+            hooks = {
+                on_message_received = {
+                    my_notifier = function(k, msg)
+                        if msg.header.msg_type == "execute_reply" then
+                            vim.notify(k.spec.display_name .. ": execution complete")
+                        end
+                    end
+                }
+            }
+        })
+<
+    Fields: ~
+        • {on_execution_state_changed}  (`table<any,fun(k: jet.Kernel, state: jet.Kernel.execution_state)>`)
+        • {on_kernel_close}             (`table<any,fun(k: jet.Kernel)>`)
+        • {on_kernel_init}              (`table<any,fun(k: jet.Kernel)>`)
+        • {on_lua_client_start}         (`table<any,fun(k: jet.Kernel)>`)
+        • {on_message_received}         (`table<any,fun(k: jet.Kernel, msg: jupyter.Msg)>`)
+        • {on_send_pre}                 (`table<any,fun(k: jet.Kernel, code: string[])>`)
+        • {on_status_changed}           (`table<any,fun(k: jet.Kernel)>`)
+        • {on_image_display_pre}        (`table<any,fun(k: jet.Kernel, file: string)>`)
+        • {on_primary_status_changed}   (`table<any,fun(k: jet.Kernel, primary: boolean)>`)
 
 *jet.Kernel*
 

--- a/docs/jet.md
+++ b/docs/jet.md
@@ -3,14 +3,21 @@
 jet.nvim is a Jupyter client/API for Neovim, built on top of the
 [Jet](https://github.com/wurli/jet) CLI/Lua library.
 
-## Lua API
+## Installation
+
+``` lua
+vim.pack.add("https://github.com/wurli/jet.nvim")
+require("jet").setup()
+```
+
+The full set of configuration options is as follows:
 
 ```{.sh include=true}
 python3 scripts/emmylua-to-md.py --type jet.Config.Opts
 ```
 
 ```{.sh include=true}
-python3 scripts/emmylua-to-md.py --type jet.Config.Hooks
+python3 scripts/emmylua-to-md.py --type jet.Hooks
 ```
 
 

--- a/lua/jet/api.lua
+++ b/lua/jet/api.lua
@@ -1,0 +1,64 @@
+local manager = require("jet.core.manager")
+local motion = require("jet.core.send.motion")
+local range_get = require("jet.core.send.get_range")
+
+local M = {}
+
+---@param opts? jet.send.next_expr_boundary.Opts
+---@param p? jet.send.Pos
+---@return jet.send.Pos?
+M.next_expr_boundary = function(opts, p) return motion.next_expr_boundary(opts, p) end
+
+---@param p? jet.send.Pos
+---@return jet.send.Range?
+M.get_expr = function(p) return range_get.get_expr(p) end
+
+---Can be used in mappings to handle the code moved over by a motion:
+---
+---```lua
+---vim.keymap.set(
+--    { "n", "v" },
+--    "gj",
+--    require("jet.api").get_motion(vim.print),
+--    { expr = true }
+--)
+---```
+---
+---@param callback fun(code: jet.send.Range, filetype: string?)
+---@return fun(): "g@" # A function that can be used in an operator-pending mapping
+M.handle_motion = function(callback) return range_get.handle_motion(callback) end
+
+---@param filters? jet.api.Filters
+---@param callback? fun(kernels: jet.Kernel[])
+---@return jet.Kernel[]?
+M.list_kernels = function(filters, callback) return manager.list(filters, callback) end
+
+---Get a kernel and do some stuff with it
+---
+---Looks for kernels which match `filters` in the following order:
+---1. Connected (or connecting) kernels
+---2. Inactive kernels which are marked as 'default'
+---3. Other inactive kernels
+---
+---If any of the above steps match a single kernel it is passed to
+---`callback()`. If multiple kernels match, the user is prompted to select one.
+---
+---@param filters jet.api.Filters
+---@param callback fun(k: jet.Kernel)
+M.get_kernel = function(filters, callback) return manager.get(filters, callback) end
+
+---Get a running kernel by its session id
+---
+---This can be useful, e.g. if you want to get the running `Kernel` object
+---powering the repl:
+---
+---``` lua
+---local jet = require("jet")
+---local kernel = jet.get_by_id(vim.b.jet.session_id)
+---```
+---
+---@param session_id string
+---@return jet.Kernel?
+M.get_kernel_by_id = function(session_id) return manager.get_by_id(session_id) end
+
+return M

--- a/lua/jet/core/send/get_range.lua
+++ b/lua/jet/core/send/get_range.lua
@@ -19,9 +19,10 @@ M.get_auto = function(p)
 	return M.get_expr(p)
 end
 
----@param p jet.send.Pos
+---@param p? jet.send.Pos
 ---@return jet.send.Range?
 M.get_expr = function(p)
+	p = p or pos.get_curr()
 	-- Note: we want the filetype at the _cursor_, not the buffer filetype
 	local ft = p:lang_info().filetype
 	local ft_module = require("jet").filetype[ft] or {}
@@ -30,6 +31,8 @@ M.get_expr = function(p)
 		if out and not out.code then
 			out = range.new(out)
 		end
+		-- Might be nil - but better not fall back to line if a ft module is
+		-- present as this could be confusing.
 		return out
 	end
 

--- a/lua/jet/core/send/motion.lua
+++ b/lua/jet/core/send/motion.lua
@@ -2,13 +2,12 @@ local pos = require("jet.core.send.pos")
 
 local M = {}
 
----@class jet.send.next_significant_line.Opts
+---@class jet.send.next_expr_boundary.Opts
 ---@field direction? 1 | -1
 ---@field boundary? "start" | "end" | "any"
 ---@field current_ok? boolean
----@field _no_recurse? boolean
 
----@param opts? jet.send.next_significant_line.Opts
+---@param opts? jet.send.next_expr_boundary.Opts
 ---@param p? jet.send.Pos
 ---@return jet.send.Pos?
 M.next_expr_boundary = function(opts, p)
@@ -58,7 +57,6 @@ M.next_expr_boundary = function(opts, p)
 				local nudged = r_end:nudge(opts.direction)
 				if nudged then
 					opts.current_ok = true
-					opts._no_recurse = true
 					out = M.next_expr_boundary(opts, nudged)
 				end
 			end
@@ -71,7 +69,6 @@ M.next_expr_boundary = function(opts, p)
 				local nudged = r_start:nudge(opts.direction)
 				if nudged then
 					opts.current_ok = true
-					opts._no_recurse = true
 					out = M.next_expr_boundary(opts, nudged)
 				end
 			end
@@ -93,7 +90,7 @@ end
 
 ---Get the next position in a buffer which is not empty or a comment
 ---
----@param opts? jet.send.next_significant_line.Opts
+---@param opts? jet.send.next_expr_boundary.Opts
 ---@param p? jet.send.Pos
 ---@return jet.send.Pos?
 M.next_significant_pos = function(opts, p)

--- a/lua/jet/core/send/range.lua
+++ b/lua/jet/core/send/range.lua
@@ -35,7 +35,7 @@ end
 ---@return_overload string[], string
 function Range:code(opts)
 	opts = opts or {}
-	local text = Range.text(self)
+	local text = self:text()
 
 	if not text then
 		return

--- a/tests/test_motions.lua
+++ b/tests/test_motions.lua
@@ -89,7 +89,7 @@ local T = MiniTest.new_set({
 	},
 })
 
----@param opts jet.send.next_significant_line.Opts
+---@param opts jet.send.next_expr_boundary.Opts
 local next_expr_boundary = function(opts)
 	local out = child.lua_get(
 		string.format(


### PR DESCRIPTION
- **fix(kernel):  missing `local`**
- **feat(send): allow next_significant_line() w/o args**
- **refactor(term): don't accept callback in Term:send()**
- **refactor: minor refactoring to send utils**
- **fix(get): don't fall back to no filters**
- **feat(send): add text object**
- **chore: remove dead code**
- **feat(send): more granular motions**
- **feat(send): restore next_significant_pos()**
- **feat(send): next_expr_boundary()**
- **test: motion stuff**
- **test: use different get_expr impl**
- **fix: make next_significant_pos() handle in-line granularity**
- **test(send): add some actual test cases for expr boundaries**
- **fix(send): failing test**
- **fix(send): failure to get next expr when called from an expr which is within another one**
- **feta(send): give an informative message if expr couldn't be found**
- **feat(send): graceful failure on unhandled expr code**
- **refactor(textobject): require a Range input**
- **refactor(tests): break up single test in test_image.lua**
- **chore: remove debug code**
- **refactor(send): reorganise files**
- **feat(kernel): add Kernel:set_primary()**
- **chore(emmylua): missing type**
- **refactor(send): add metatables for Range and Pos**
- **refactor(send): pull some fns into methods of Pos**
- **feat!(send): move filetype extensions to jet.filetype[ft]**
- **chore(send): delete dead code**
- **refactor(send): rename utils to motion**
- **build: make docs**
- **fix: failing test**
- **refactor: misc tidying**
- **feat: add jet/api.lua**
- **docs: minor tweaks**
